### PR TITLE
Usability improvements for controlled list manager

### DIFF
--- a/arches_controlled_lists/management/commands/packages.py
+++ b/arches_controlled_lists/management/commands/packages.py
@@ -1,14 +1,12 @@
-import os, sys
-import logging
+import os
+import sys
+
 import openpyxl
-from arches.management.commands.packages import Command as PackagesCommand
-from arches.app.models.system_settings import settings
-from arches.app.models import models
-from arches_controlled_lists.models import List, ListItem, ListItemValue
 from django.db import transaction
 
-
-logger = logging.getLogger(__name__)
+from arches.management.commands.packages import Command as PackagesCommand
+from arches.app.models import models
+from arches_controlled_lists.models import List, ListItem, ListItemValue
 
 
 class Command(PackagesCommand):
@@ -151,8 +149,6 @@ class Command(PackagesCommand):
         self.export_model_to_sheet(wb, ListItem)
         self.export_model_to_sheet(wb, ListItemValue)
 
-        # if data_dest == ".":
-        #     data_dest = os.path.dirname(settings.SYSTEM_SETTINGS_LOCAL_PATH)
         if data_dest != "" and data_dest != ".":
             wb.save(os.path.join(data_dest, file_name))
             self.stdout.write(f"Data exported successfully to {file_name}")

--- a/arches_controlled_lists/media/js/views/components/plugins/controlled-list-manager.js
+++ b/arches_controlled_lists/media/js/views/components/plugins/controlled-list-manager.js
@@ -10,8 +10,8 @@ import ControlledListManagerTemplate from 'templates/views/components/plugins/co
 import { createRouter, createWebHistory } from 'vue-router';
 
 const router = createRouter({
-  history: createWebHistory(),
-  routes,
+    history: createWebHistory(),
+    routes,
 });
 
 const ControlledListsPreset = definePreset(ArchesPreset, {

--- a/arches_controlled_lists/media/js/views/components/plugins/controlled-list-manager.js
+++ b/arches_controlled_lists/media/js/views/components/plugins/controlled-list-manager.js
@@ -26,6 +26,10 @@ const ControlledListsPreset = definePreset(ArchesPreset, {
                 },
             },
         },
+        toast: {
+            summary: { fontSize: '1.5rem' },
+            detail: { fontSize: '1.25rem' },
+        },
     },
 });
 

--- a/arches_controlled_lists/models.py
+++ b/arches_controlled_lists/models.py
@@ -348,7 +348,7 @@ class ListItemImageMetadata(models.Model):
         to_field="code",
         on_delete=models.PROTECT,
     )
-    metadata_type = models.CharField(max_length=5, choices=MetadataChoices.choices)
+    metadata_type = models.CharField(max_length=5, choices=MetadataChoices)
     value = models.CharField(max_length=2048)
 
     class Meta:

--- a/arches_controlled_lists/src/arches_controlled_lists/components/ControlledListsMain.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/ControlledListsMain.vue
@@ -62,10 +62,8 @@ provide(systemLanguageKey, systemLanguage);
     </div>
     <Toast
         :pt="{
-            summary: { fontSize: 'medium' },
-            detail: { fontSize: 'small' },
             messageIcon: {
-                style: { marginTop: 'var(--p-toast-message-icon-margin-top)' },
+                style: { marginTop: 'var(--p-toast-text-gap)' },
             },
         }"
     />

--- a/arches_controlled_lists/src/arches_controlled_lists/components/ControlledListsMain.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/ControlledListsMain.vue
@@ -19,6 +19,7 @@ import {
 } from "@/arches_controlled_lists/constants.ts";
 import { routeNames } from "@/arches_controlled_lists/routes.ts";
 import {
+    commandeerFocusFromDataTable,
     dataIsList,
     shouldUseContrast,
 } from "@/arches_controlled_lists/utils.ts";
@@ -83,16 +84,9 @@ const confirmLeave = (row: Selectable) => {
             isEditing.value = false;
             finishSettingDisplayedRow(row);
         },
-        reject: () => {
-            setTimeout(
-                () =>
-                    lastFocusedElement.value &&
-                    // @ts-expect-error focusVisible not yet in typeshed
-
-                    lastFocusedElement.value.focus({ focusVisible: true }),
-                25,
-            );
-        },
+        reject: () =>
+            lastFocusedElement.value &&
+            commandeerFocusFromDataTable(lastFocusedElement.value),
     });
 };
 

--- a/arches_controlled_lists/src/arches_controlled_lists/components/ControlledListsMain.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/ControlledListsMain.vue
@@ -14,6 +14,7 @@ import {
     SECONDARY,
     ENGLISH,
     displayedRowKey,
+    isEditingKey,
     selectedLanguageKey,
     systemLanguageKey,
 } from "@/arches_controlled_lists/constants.ts";
@@ -46,6 +47,10 @@ const setDisplayedRow = (val: Selectable | null) => {
         finishSettingDisplayedRow(val);
     }
 };
+
+function setIsEditing(val: boolean) {
+    isEditing.value = val;
+}
 
 const finishSettingDisplayedRow = (val: Selectable | null) => {
     displayedRow.value = val;
@@ -90,10 +95,8 @@ const confirmLeave = (row: Selectable) => {
     });
 };
 
-// @ts-expect-error vue-tsc doesn't like arbitrary properties here
 provide(displayedRowKey, { displayedRow, setDisplayedRow });
-provide("isEditing", isEditing);
-
+provide(isEditingKey, { isEditing, setIsEditing });
 const selectedLanguage: Ref<Language> = ref(
     (arches.languages as Language[]).find(
         (lang) => lang.code === arches.activeLanguage,

--- a/arches_controlled_lists/src/arches_controlled_lists/components/MainSplitter.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/MainSplitter.vue
@@ -10,7 +10,7 @@ import { routeNames } from "@/arches_controlled_lists/routes.ts";
 import { dataIsList } from "@/arches_controlled_lists/utils.ts";
 import ControlledListSplash from "@/arches_controlled_lists/components/misc/ControlledListSplash.vue";
 import ItemEditor from "@/arches_controlled_lists/components/editor/ItemEditor.vue";
-import ListCharacteristics from "@/arches_controlled_lists/components/editor/ListCharacteristics.vue";
+import ListEditor from "@/arches_controlled_lists/components/editor/ListEditor.vue";
 import ListTree from "@/arches_controlled_lists/components/tree/ListTree.vue";
 
 import type { Ref } from "vue";
@@ -25,7 +25,7 @@ const panel = computed(() => {
         return ControlledListSplash;
     }
     if (dataIsList(displayedRow.value)) {
-        return ListCharacteristics;
+        return ListEditor;
     }
     return ItemEditor;
 });
@@ -56,6 +56,7 @@ const panel = computed(() => {
         >
             <component
                 :is="panel"
+                ref="editor"
                 :key="displayedRow?.id ?? routeNames.splash"
             />
         </SplitterPanel>

--- a/arches_controlled_lists/src/arches_controlled_lists/components/MainSplitter.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/MainSplitter.vue
@@ -6,7 +6,6 @@ import Splitter from "primevue/splitter";
 import SplitterPanel from "primevue/splitterpanel";
 
 import { displayedRowKey } from "@/arches_controlled_lists/constants.ts";
-import { routeNames } from "@/arches_controlled_lists/routes.ts";
 import { dataIsList } from "@/arches_controlled_lists/utils.ts";
 import ControlledListSplash from "@/arches_controlled_lists/components/misc/ControlledListSplash.vue";
 import ItemEditor from "@/arches_controlled_lists/components/editor/ItemEditor.vue";
@@ -44,18 +43,9 @@ const { displayedRow } = inject(displayedRowKey) as unknown as {
                 paddingRight: '2rem',
             }"
         >
-            <ControlledListSplash
-                v-if="!displayedRow"
-                :key="routeNames.splash"
-            />
-            <ListEditor
-                v-else-if="dataIsList(displayedRow)"
-                :key="displayedRow.id ?? routeNames.list"
-            />
-            <ItemEditor
-                v-else
-                :key="displayedRow.id ?? routeNames.item"
-            />
+            <ControlledListSplash v-if="!displayedRow" />
+            <ListEditor v-else-if="dataIsList(displayedRow)" />
+            <ItemEditor v-else />
         </SplitterPanel>
     </Splitter>
 </template>

--- a/arches_controlled_lists/src/arches_controlled_lists/components/MainSplitter.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/MainSplitter.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, inject } from "vue";
+import { inject } from "vue";
 
 import ProgressSpinner from "primevue/progressspinner";
 import Splitter from "primevue/splitter";
@@ -19,16 +19,6 @@ import type { ControlledList } from "@/arches_controlled_lists/types";
 const { displayedRow } = inject(displayedRowKey) as unknown as {
     displayedRow: Ref<ControlledList>;
 };
-
-const panel = computed(() => {
-    if (!displayedRow.value) {
-        return ControlledListSplash;
-    }
-    if (dataIsList(displayedRow.value)) {
-        return ListEditor;
-    }
-    return ItemEditor;
-});
 </script>
 
 <template>
@@ -54,10 +44,17 @@ const panel = computed(() => {
                 paddingRight: '2rem',
             }"
         >
-            <component
-                :is="panel"
-                ref="editor"
-                :key="displayedRow?.id ?? routeNames.splash"
+            <ControlledListSplash
+                v-if="!displayedRow"
+                :key="routeNames.splash"
+            />
+            <ListEditor
+                v-else-if="dataIsList(displayedRow)"
+                :key="displayedRow.id ?? routeNames.list"
+            />
+            <ItemEditor
+                v-else
+                :key="displayedRow.id ?? routeNames.item"
             />
         </SplitterPanel>
     </Splitter>

--- a/arches_controlled_lists/src/arches_controlled_lists/components/editor/AddMetadata.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/editor/AddMetadata.vue
@@ -6,6 +6,7 @@ import { useGettext } from "vue3-gettext";
 import Button from "primevue/button";
 
 import {
+    isEditingKey,
     itemKey,
     CONTRAST,
     PRIMARY,
@@ -20,6 +21,7 @@ import type {
     ControlledListItem,
     ControlledListItemImage,
     ControlledListItemImageMetadata,
+    IsEditingRefAndSetter,
     LabeledChoice,
 } from "@/arches_controlled_lists/types";
 
@@ -32,6 +34,7 @@ const { labeledChoices, image, makeMetadataEditable } = defineProps<{
     ) => void;
 }>();
 const item = inject(itemKey) as Ref<ControlledListItem>;
+const { isEditing } = inject(isEditingKey) as IsEditingRefAndSetter;
 
 const { $gettext } = useGettext();
 
@@ -76,6 +79,7 @@ const addMetadata = () => {
         icon="fa fa-plus-circle"
         :severity="shouldUseContrast() ? CONTRAST : PRIMARY"
         :label="$gettext('Add metadata')"
+        :disabled="isEditing"
         @click="addMetadata"
     />
 </template>

--- a/arches_controlled_lists/src/arches_controlled_lists/components/editor/AddValue.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/editor/AddValue.vue
@@ -7,6 +7,7 @@ import Button from "primevue/button";
 
 import { ALT_LABEL, PREF_LABEL } from "@/arches_vue_utils/constants.ts";
 import {
+    isEditingKey,
     itemKey,
     CONTRAST,
     NOTE_CHOICES,
@@ -21,6 +22,7 @@ import type { Ref } from "vue";
 import type { Language } from "@/arches_vue_utils/types";
 import type {
     ControlledListItem,
+    IsEditingRefAndSetter,
     Value,
     ValueType,
 } from "@/arches_controlled_lists/types";
@@ -30,6 +32,7 @@ const { valueType, makeNewValueEditable } = defineProps<{
     makeNewValueEditable: (newValue: Value, index: number) => void;
 }>();
 const item = inject(itemKey) as Ref<ControlledListItem>;
+const { isEditing } = inject(isEditingKey) as IsEditingRefAndSetter;
 
 const { $gettext } = useGettext();
 
@@ -104,6 +107,7 @@ const addValue = () => {
         icon="fa fa-plus-circle"
         :severity="shouldUseContrast() ? CONTRAST : PRIMARY"
         :label="buttonLabel"
+        :disabled="isEditing"
         @click="addValue"
     />
 </template>

--- a/arches_controlled_lists/src/arches_controlled_lists/components/editor/ImageEditor.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/editor/ImageEditor.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import arches from "arches";
-import { computed, inject, useTemplateRef } from "vue";
+import { computed, inject } from "vue";
 
 import { getItemLabel } from "@/arches_vue_utils/utils.ts";
 import {
@@ -16,8 +16,6 @@ import type {
     ControlledListItem,
     ControlledListItemImage,
 } from "@/arches_controlled_lists/types";
-
-const metadataEditor = useTemplateRef("metadataEditor");
 
 const item = inject(itemKey) as Ref<ControlledListItem>;
 const systemLanguage = inject(systemLanguageKey) as Language;
@@ -58,9 +56,6 @@ const bestAlternativeText = computed(() => {
             :alt="bestAlternativeText"
             width="200"
         />
-        <ImageMetadata
-            ref="metadataEditor"
-            :image="image"
-        />
+        <ImageMetadata :image="image" />
     </div>
 </template>

--- a/arches_controlled_lists/src/arches_controlled_lists/components/editor/ImageEditor.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/editor/ImageEditor.vue
@@ -48,8 +48,6 @@ const bestAlternativeText = computed(() => {
             .value
     );
 });
-
-defineExpose({ isEditing: metadataEditor.value?.isEditing });
 </script>
 
 <template>

--- a/arches_controlled_lists/src/arches_controlled_lists/components/editor/ImageEditor.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/editor/ImageEditor.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import arches from "arches";
-import { computed, inject } from "vue";
+import { computed, inject, useTemplateRef } from "vue";
 
 import { getItemLabel } from "@/arches_vue_utils/utils.ts";
 import {
@@ -16,6 +16,8 @@ import type {
     ControlledListItem,
     ControlledListItemImage,
 } from "@/arches_controlled_lists/types";
+
+const metadataEditor = useTemplateRef("metadataEditor");
 
 const item = inject(itemKey) as Ref<ControlledListItem>;
 const systemLanguage = inject(systemLanguageKey) as Language;
@@ -42,13 +44,12 @@ const bestAlternativeText = computed(() => {
             )
             .find((altText) => altText.language_id === arches.activeLanguage)
             ?.value ||
-        getItemLabel(
-            item.value,
-            arches.activeLanguage.code,
-            systemLanguage.code,
-        ).value
+        getItemLabel(item.value, arches.activeLanguage, systemLanguage.code)
+            .value
     );
 });
+
+defineExpose({ isEditing: metadataEditor.value?.isEditing });
 </script>
 
 <template>
@@ -59,6 +60,9 @@ const bestAlternativeText = computed(() => {
             :alt="bestAlternativeText"
             width="200"
         />
-        <ImageMetadata :image="image" />
+        <ImageMetadata
+            ref="metadataEditor"
+            :image="image"
+        />
     </div>
 </template>

--- a/arches_controlled_lists/src/arches_controlled_lists/components/editor/ImageMetadata.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/editor/ImageMetadata.vue
@@ -73,6 +73,14 @@ const labeledChoices: LabeledChoice[] = [
     },
 ];
 
+const isEditing = computed(() => {
+    return editingRows.value.length > 0;
+});
+
+const inputSelector = computed(() => {
+    return `[data-p-index="${rowIndexToFocus.value}"]`;
+});
+
 const metadataLabel = (metadataType: string) => {
     return labeledChoices.find((choice) => choice.type === metadataType)!.label;
 };
@@ -109,6 +117,7 @@ const saveMetadata = async (event: DataTableRowEditInitEvent) => {
 const issueDeleteMetadata = async (
     metadata: ControlledListItemImageMetadata,
 ) => {
+    makeRowUneditable(metadata.id);
     if (dataIsNew(metadata)) {
         removeImageMetadata(metadata);
         return;
@@ -216,9 +225,11 @@ const setRowFocus = (event: DataTableRowEditInitEvent) => {
     rowIndexToFocus.value = event.index;
 };
 
-const inputSelector = computed(() => {
-    return `[data-p-index="${rowIndexToFocus.value}"]`;
-});
+const makeRowUneditable = (metadataId: string) => {
+    editingRows.value = [
+        ...editingRows.value.filter((metadatum) => metadatum.id !== metadataId),
+    ];
+};
 
 const focusInput = () => {
     // The editor (pencil) button from the DataTable (elsewhere on page)
@@ -235,6 +246,8 @@ const focusInput = () => {
         rowIndexToFocus.value = -1;
     }, 25);
 };
+
+defineExpose({ isEditing });
 </script>
 
 <template>
@@ -247,6 +260,7 @@ const focusInput = () => {
             edit-mode="row"
             striped-rows
             :style="{ fontSize: 'small' }"
+            @row-edit-cancel="(event) => makeRowUneditable(event.data.id)"
             @row-edit-init="setRowFocus"
             @row-edit-save="saveMetadata"
         >

--- a/arches_controlled_lists/src/arches_controlled_lists/components/editor/ImageMetadata.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/editor/ImageMetadata.vue
@@ -226,11 +226,11 @@ const setRowFocus = (event: DataTableRowEditInitEvent) => {
     rowIndexToFocus.value = event.index;
 };
 
-const makeRowUneditable = (metadataId: string) => {
+function makeRowUneditable(metadataId: string) {
     editingRows.value = [
         ...editingRows.value.filter((metadatum) => metadatum.id !== metadataId),
     ];
-};
+}
 
 const focusInput = () => {
     if (rowIndexToFocus.value !== -1) {

--- a/arches_controlled_lists/src/arches_controlled_lists/components/editor/ImageMetadata.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/editor/ImageMetadata.vue
@@ -24,6 +24,7 @@ import {
     itemKey,
 } from "@/arches_controlled_lists/constants.ts";
 import {
+    commandeerFocusFromDataTable,
     dataIsNew,
     languageNameFromCode,
     shouldUseContrast,
@@ -232,19 +233,12 @@ const makeRowUneditable = (metadataId: string) => {
 };
 
 const focusInput = () => {
-    // The editor (pencil) button from the DataTable (elsewhere on page)
-    // immediately hogs focus with a setTimeout of 1,
-    // so we'll get in line behind it to set focus to the input.
-    // This should be reported/clarified with PrimeVue with a MWE.
-    setTimeout(() => {
-        if (rowIndexToFocus.value !== -1) {
-            const rowEl = editorDiv.value!.querySelector(inputSelector.value);
-            const inputEl = rowEl!.children[1].children[0];
-            // @ts-expect-error focusVisible not yet in typeshed
-            (inputEl as HTMLInputElement).focus({ focusVisible: true });
-        }
+    if (rowIndexToFocus.value !== -1) {
+        const rowEl = editorDiv.value!.querySelector(inputSelector.value);
+        const inputEl = rowEl!.children[1].children[0] as HTMLInputElement;
+        commandeerFocusFromDataTable(inputEl);
         rowIndexToFocus.value = -1;
-    }, 25);
+    }
 };
 
 defineExpose({ isEditing });

--- a/arches_controlled_lists/src/arches_controlled_lists/components/editor/ItemEditor.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/editor/ItemEditor.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { inject, provide } from "vue";
+import { inject, provide, useTemplateRef, watch } from "vue";
 
 import ItemHeader from "@/arches_controlled_lists/components/editor/ItemHeader.vue";
 import ItemImages from "@/arches_controlled_lists/components/editor/ItemImages.vue";
@@ -17,20 +17,56 @@ import {
 import type { Ref } from "vue";
 import type { ControlledListItem } from "@/arches_controlled_lists/types";
 
+const prefLabelEditor = useTemplateRef("prefLabelEditor");
+const altLabelEditor = useTemplateRef("altLabelEditor");
+const noteEditor = useTemplateRef("noteEditor");
+const uriEditor = useTemplateRef("uriEditor");
+const imageEditor = useTemplateRef("imageEditor");
+
 const { displayedRow: item } = inject(displayedRowKey) as unknown as {
     displayedRow: Ref<ControlledListItem>;
 };
 provide(itemKey, item);
+
+const isEditing = inject("isEditing") as Ref<boolean>;
+
+watch(
+    [
+        () => prefLabelEditor.value?.isEditing,
+        () => altLabelEditor.value?.isEditing,
+        () => noteEditor.value?.isEditing,
+        () => uriEditor.value?.isEditing,
+        () => imageEditor.value?.isEditing,
+    ],
+    () => {
+        isEditing.value =
+            prefLabelEditor.value?.isEditing ||
+            altLabelEditor.value?.isEditing ||
+            noteEditor.value?.isEditing ||
+            uriEditor.value?.isEditing ||
+            imageEditor.value?.isEditing ||
+            false;
+    },
+);
 </script>
 
 <template>
     <template v-if="item">
         <ItemHeader />
-        <ValueEditor :value-type="PREF_LABEL" />
-        <ValueEditor :value-type="ALT_LABEL" />
+        <ValueEditor
+            ref="prefLabelEditor"
+            :value-type="PREF_LABEL"
+        />
+        <ValueEditor
+            ref="altLabelEditor"
+            :value-type="ALT_LABEL"
+        />
         <ItemType />
-        <ValueEditor :value-category="NOTE" />
-        <ItemURI />
-        <ItemImages />
+        <ValueEditor
+            ref="noteEditor"
+            :value-category="NOTE"
+        />
+        <ItemURI ref="uriEditor" />
+        <ItemImages ref="imageEditor" />
     </template>
 </template>

--- a/arches_controlled_lists/src/arches_controlled_lists/components/editor/ItemEditor.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/editor/ItemEditor.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { inject, provide, useTemplateRef, watch } from "vue";
+import { inject, provide } from "vue";
 
 import ItemHeader from "@/arches_controlled_lists/components/editor/ItemHeader.vue";
 import ItemImages from "@/arches_controlled_lists/components/editor/ItemImages.vue";
@@ -17,56 +17,20 @@ import {
 import type { Ref } from "vue";
 import type { ControlledListItem } from "@/arches_controlled_lists/types";
 
-const prefLabelEditor = useTemplateRef("prefLabelEditor");
-const altLabelEditor = useTemplateRef("altLabelEditor");
-const noteEditor = useTemplateRef("noteEditor");
-const uriEditor = useTemplateRef("uriEditor");
-const imageEditor = useTemplateRef("imageEditor");
-
 const { displayedRow: item } = inject(displayedRowKey) as unknown as {
     displayedRow: Ref<ControlledListItem>;
 };
 provide(itemKey, item);
-
-const isEditing = inject("isEditing") as Ref<boolean>;
-
-watch(
-    [
-        () => prefLabelEditor.value?.isEditing,
-        () => altLabelEditor.value?.isEditing,
-        () => noteEditor.value?.isEditing,
-        () => uriEditor.value?.isEditing,
-        () => imageEditor.value?.isEditing,
-    ],
-    () => {
-        isEditing.value =
-            prefLabelEditor.value?.isEditing ||
-            altLabelEditor.value?.isEditing ||
-            noteEditor.value?.isEditing ||
-            uriEditor.value?.isEditing ||
-            imageEditor.value?.isEditing ||
-            false;
-    },
-);
 </script>
 
 <template>
     <template v-if="item">
         <ItemHeader />
-        <ValueEditor
-            ref="prefLabelEditor"
-            :value-type="PREF_LABEL"
-        />
-        <ValueEditor
-            ref="altLabelEditor"
-            :value-type="ALT_LABEL"
-        />
+        <ValueEditor :value-type="PREF_LABEL" />
+        <ValueEditor :value-type="ALT_LABEL" />
         <ItemType />
-        <ValueEditor
-            ref="noteEditor"
-            :value-category="NOTE"
-        />
-        <ItemURI ref="uriEditor" />
-        <ItemImages ref="imageEditor" />
+        <ValueEditor :value-category="NOTE" />
+        <ItemURI />
+        <ItemImages />
     </template>
 </template>

--- a/arches_controlled_lists/src/arches_controlled_lists/components/editor/ItemImages.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/editor/ItemImages.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import arches from "arches";
 import Cookies from "js-cookie";
-import { computed, inject, useTemplateRef } from "vue";
+import { inject, useTemplateRef } from "vue";
 import { useGettext } from "vue3-gettext";
 
 import FileUpload from "primevue/fileupload";
@@ -38,15 +38,6 @@ const toast = useToast();
 const item = inject(itemKey) as Ref<ControlledListItem>;
 const editors = useTemplateRef("editors");
 
-const isEditing = computed(() => {
-    return (
-        Boolean(editors.value) &&
-        (editors.value as unknown as (typeof ImageEditor)[]).some(
-            (editor) => editor.isEditing,
-        )
-    );
-});
-
 const addHeader = (event: FileUploadBeforeSendEvent) => {
     const token = Cookies.get("csrftoken");
     if (token) {
@@ -72,8 +63,6 @@ const showError = (event?: FileUploadErrorEvent | FileUploadUploadEvent) => {
         detail: JSON.parse(event?.xhr?.responseText ?? "{}").message,
     });
 };
-
-defineExpose({ isEditing });
 </script>
 
 <template>

--- a/arches_controlled_lists/src/arches_controlled_lists/components/editor/ItemImages.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/editor/ItemImages.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import arches from "arches";
 import Cookies from "js-cookie";
-import { inject, useTemplateRef } from "vue";
+import { inject } from "vue";
 import { useGettext } from "vue3-gettext";
 
 import FileUpload from "primevue/fileupload";
@@ -36,7 +36,6 @@ const { $gettext } = useGettext();
 const toast = useToast();
 
 const item = inject(itemKey) as Ref<ControlledListItem>;
-const editors = useTemplateRef("editors");
 
 const addHeader = (event: FileUploadBeforeSendEvent) => {
     const token = Cookies.get("csrftoken");
@@ -100,7 +99,6 @@ const showError = (event?: FileUploadErrorEvent | FileUploadUploadEvent) => {
         <div class="images">
             <ImageEditor
                 v-for="image in item.images"
-                ref="editors"
                 :key="image.id"
                 :image="image"
             />

--- a/arches_controlled_lists/src/arches_controlled_lists/components/editor/ItemImages.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/editor/ItemImages.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import arches from "arches";
 import Cookies from "js-cookie";
-import { inject } from "vue";
+import { computed, inject, useTemplateRef } from "vue";
 import { useGettext } from "vue3-gettext";
 
 import FileUpload from "primevue/fileupload";
@@ -32,10 +32,20 @@ interface FileUploadInternals {
     state: FileUploadState;
 }
 
-const item = inject(itemKey) as Ref<ControlledListItem>;
-
 const { $gettext } = useGettext();
 const toast = useToast();
+
+const item = inject(itemKey) as Ref<ControlledListItem>;
+const editors = useTemplateRef("editors");
+
+const isEditing = computed(() => {
+    return (
+        Boolean(editors.value) &&
+        (editors.value as unknown as (typeof ImageEditor)[]).some(
+            (editor) => editor.isEditing,
+        )
+    );
+});
 
 const addHeader = (event: FileUploadBeforeSendEvent) => {
     const token = Cookies.get("csrftoken");
@@ -62,6 +72,8 @@ const showError = (event?: FileUploadErrorEvent | FileUploadUploadEvent) => {
         detail: JSON.parse(event?.xhr?.responseText ?? "{}").message,
     });
 };
+
+defineExpose({ isEditing });
 </script>
 
 <template>
@@ -99,6 +111,7 @@ const showError = (event?: FileUploadErrorEvent | FileUploadUploadEvent) => {
         <div class="images">
             <ImageEditor
                 v-for="image in item.images"
+                ref="editors"
                 :key="image.id"
                 :image="image"
             />

--- a/arches_controlled_lists/src/arches_controlled_lists/components/editor/ItemURI.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/editor/ItemURI.vue
@@ -9,16 +9,23 @@ import { patchItem } from "@/arches_controlled_lists/api.ts";
 import {
     DEFAULT_ERROR_TOAST_LIFE,
     ERROR,
+    isEditingKey,
     itemKey,
 } from "@/arches_controlled_lists/constants.ts";
 import { vFocus } from "@/arches_controlled_lists/utils.ts";
 
 import type { Ref } from "vue";
-import type { ControlledListItem } from "@/arches_controlled_lists/types";
+import type {
+    ControlledListItem,
+    IsEditingRefAndSetter,
+} from "@/arches_controlled_lists/types";
 
 const item = inject(itemKey) as Ref<ControlledListItem>;
+const { isEditing, setIsEditing } = inject(
+    isEditingKey,
+) as IsEditingRefAndSetter;
 
-const isEditing = ref(false);
+const isEditingUri = ref(false);
 const formValue = ref("");
 
 const inputValue = computed({
@@ -35,7 +42,8 @@ const { $gettext } = useGettext();
 const uri = "uri";
 
 const save = async () => {
-    isEditing.value = false;
+    setIsEditing(false);
+    isEditingUri.value = false;
     const originalValue = item.value.uri;
     item.value.uri = formValue.value;
 
@@ -52,12 +60,18 @@ const save = async () => {
     }
 };
 
-const cancel = () => {
-    isEditing.value = false;
+function cancel() {
+    setIsEditing(false);
+    isEditingUri.value = false;
     formValue.value = item.value.uri;
-};
+}
 
-defineExpose({ isEditing });
+function tryEdit() {
+    if (!isEditing.value) {
+        isEditing.value = true;
+        isEditingUri.value = true;
+    }
+}
 </script>
 
 <template>
@@ -75,13 +89,13 @@ defineExpose({ isEditing });
                 v-model="inputValue"
                 v-focus
                 type="text"
-                :disabled="!isEditing"
+                :disabled="!isEditing || !isEditingUri"
                 :aria-label="$gettext('Enter a URI')"
                 :placeholder="$gettext('Enter a URI')"
                 @keyup.enter="save"
             />
             <span
-                v-if="!isEditing"
+                v-if="!isEditingUri"
                 class="edit-controls"
             >
                 <i
@@ -89,12 +103,12 @@ defineExpose({ isEditing });
                     tabindex="0"
                     class="fa fa-pencil"
                     :aria-label="$gettext('Edit')"
-                    @click="isEditing = true"
-                    @keyup.enter="isEditing = true"
+                    @click="tryEdit"
+                    @keyup.enter="tryEdit"
                 />
             </span>
             <span
-                v-if="isEditing"
+                v-if="isEditingUri"
                 class="edit-controls"
             >
                 <i

--- a/arches_controlled_lists/src/arches_controlled_lists/components/editor/ItemURI.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/editor/ItemURI.vue
@@ -18,7 +18,7 @@ import type { ControlledListItem } from "@/arches_controlled_lists/types";
 
 const item = inject(itemKey) as Ref<ControlledListItem>;
 
-const editing = ref(false);
+const isEditing = ref(false);
 const formValue = ref("");
 
 const inputValue = computed({
@@ -35,7 +35,7 @@ const { $gettext } = useGettext();
 const uri = "uri";
 
 const save = async () => {
-    editing.value = false;
+    isEditing.value = false;
     const originalValue = item.value.uri;
     item.value.uri = formValue.value;
 
@@ -53,9 +53,11 @@ const save = async () => {
 };
 
 const cancel = () => {
-    editing.value = false;
+    isEditing.value = false;
     formValue.value = item.value.uri;
 };
+
+defineExpose({ isEditing });
 </script>
 
 <template>
@@ -73,13 +75,13 @@ const cancel = () => {
                 v-model="inputValue"
                 v-focus
                 type="text"
-                :disabled="!editing"
+                :disabled="!isEditing"
                 :aria-label="$gettext('Enter a URI')"
                 :placeholder="$gettext('Enter a URI')"
                 @keyup.enter="save"
             />
             <span
-                v-if="!editing"
+                v-if="!isEditing"
                 class="edit-controls"
             >
                 <i
@@ -87,12 +89,12 @@ const cancel = () => {
                     tabindex="0"
                     class="fa fa-pencil"
                     :aria-label="$gettext('Edit')"
-                    @click="editing = true"
-                    @keyup.enter="editing = true"
+                    @click="isEditing = true"
+                    @keyup.enter="isEditing = true"
                 />
             </span>
             <span
-                v-if="editing"
+                v-if="isEditing"
                 class="edit-controls"
             >
                 <i

--- a/arches_controlled_lists/src/arches_controlled_lists/components/editor/ListCharacteristic.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/editor/ListCharacteristic.vue
@@ -10,11 +10,15 @@ import {
     DEFAULT_ERROR_TOAST_LIFE,
     ERROR,
     displayedRowKey,
+    isEditingKey,
 } from "@/arches_controlled_lists/constants.ts";
 import { vFocus } from "@/arches_controlled_lists/utils.ts";
 
 import type { Ref } from "vue";
-import type { ControlledList } from "@/arches_controlled_lists/types";
+import type {
+    ControlledList,
+    IsEditingRefAndSetter,
+} from "@/arches_controlled_lists/types";
 
 const props = defineProps<{
     editable: boolean;
@@ -23,8 +27,10 @@ const props = defineProps<{
 const { displayedRow: list } = inject(displayedRowKey) as unknown as {
     displayedRow: Ref<ControlledList>;
 };
+const { isEditing, setIsEditing } = inject(
+    isEditingKey,
+) as IsEditingRefAndSetter;
 
-const isEditing = ref(false);
 const disabled = computed(() => {
     return !props.editable || !isEditing.value;
 });
@@ -66,8 +72,6 @@ const cancel = () => {
     isEditing.value = false;
     formValue.value = list.value.name;
 };
-
-defineExpose({ isEditing });
 </script>
 
 <template>
@@ -78,7 +82,7 @@ defineExpose({ isEditing });
             v-if="!props.editable"
             style="font-size: small"
         >
-            False
+            {{ $gettext("False") }}
         </span>
         <InputText
             v-else
@@ -97,8 +101,8 @@ defineExpose({ isEditing });
                 tabindex="0"
                 class="fa fa-pencil"
                 :aria-label="$gettext('Edit')"
-                @click="isEditing = true"
-                @keyup.enter="isEditing = true"
+                @click="setIsEditing(true)"
+                @keyup.enter="setIsEditing(true)"
             ></i>
         </span>
         <span

--- a/arches_controlled_lists/src/arches_controlled_lists/components/editor/ListCharacteristic.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/editor/ListCharacteristic.vue
@@ -24,9 +24,9 @@ const { displayedRow: list } = inject(displayedRowKey) as unknown as {
     displayedRow: Ref<ControlledList>;
 };
 
-const editing = ref(false);
+const isEditing = ref(false);
 const disabled = computed(() => {
-    return !props.editable || !editing.value;
+    return !props.editable || !isEditing.value;
 });
 
 const formValue = ref("");
@@ -46,7 +46,7 @@ const toast = useToast();
 const { $gettext } = useGettext();
 
 const save = async () => {
-    editing.value = false;
+    isEditing.value = false;
     const originalValue = list.value.name;
     list.value.name = formValue.value.trim();
     try {
@@ -63,9 +63,11 @@ const save = async () => {
 };
 
 const cancel = () => {
-    editing.value = false;
+    isEditing.value = false;
     formValue.value = list.value.name;
 };
+
+defineExpose({ isEditing });
 </script>
 
 <template>
@@ -87,7 +89,7 @@ const cancel = () => {
             @keyup.enter="save"
         />
         <span
-            v-if="props.editable && !editing"
+            v-if="props.editable && !isEditing"
             class="edit-controls"
         >
             <i
@@ -95,12 +97,12 @@ const cancel = () => {
                 tabindex="0"
                 class="fa fa-pencil"
                 :aria-label="$gettext('Edit')"
-                @click="editing = true"
-                @keyup.enter="editing = true"
+                @click="isEditing = true"
+                @keyup.enter="isEditing = true"
             ></i>
         </span>
         <span
-            v-if="props.editable && editing"
+            v-if="props.editable && isEditing"
             class="edit-controls"
         >
             <i

--- a/arches_controlled_lists/src/arches_controlled_lists/components/editor/ListCharacteristic.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/editor/ListCharacteristic.vue
@@ -54,7 +54,7 @@ const { $gettext } = useGettext();
 const save = async () => {
     isEditing.value = false;
     const originalValue = list.value.name;
-    list.value.name = formValue.value.trim();
+    list.value.name = formValue.value.trim() || originalValue;
     try {
         await patchList(list.value!, field);
     } catch (error) {

--- a/arches_controlled_lists/src/arches_controlled_lists/components/editor/ListEditor.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/editor/ListEditor.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { inject } from "vue";
+import { inject, useTemplateRef, watch } from "vue";
 import { useGettext } from "vue3-gettext";
 
 import { displayedRowKey } from "@/arches_controlled_lists/constants.ts";
@@ -14,6 +14,19 @@ const { displayedRow: list } = inject(displayedRowKey) as unknown as {
 };
 
 const { $gettext } = useGettext();
+const isEditing = inject("isEditing") as Ref<boolean>;
+const nameEditor = useTemplateRef("nameEditor");
+const dynamicEditor = useTemplateRef("dynamicEditor");
+
+watch(
+    [() => nameEditor.value?.isEditing, () => dynamicEditor.value?.isEditing],
+    () => {
+        isEditing.value =
+            nameEditor.value?.isEditing ||
+            dynamicEditor.value?.isEditing ||
+            false;
+    },
+);
 </script>
 
 <template>
@@ -27,10 +40,12 @@ const { $gettext } = useGettext();
         </span>
         <div>
             <ListCharacteristic
+                ref="nameEditor"
                 :editable="true"
                 :label="$gettext('Name')"
             />
             <ListCharacteristic
+                ref="dynamicEditor"
                 :editable="false"
                 :label="$gettext('Dynamic')"
                 :style="{ width: '4rem' }"

--- a/arches_controlled_lists/src/arches_controlled_lists/components/editor/ListEditor.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/editor/ListEditor.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { inject, useTemplateRef, watch } from "vue";
+import { inject } from "vue";
 import { useGettext } from "vue3-gettext";
 
 import { displayedRowKey } from "@/arches_controlled_lists/constants.ts";
@@ -14,19 +14,6 @@ const { displayedRow: list } = inject(displayedRowKey) as unknown as {
 };
 
 const { $gettext } = useGettext();
-const isEditing = inject("isEditing") as Ref<boolean>;
-const nameEditor = useTemplateRef("nameEditor");
-const dynamicEditor = useTemplateRef("dynamicEditor");
-
-watch(
-    [() => nameEditor.value?.isEditing, () => dynamicEditor.value?.isEditing],
-    () => {
-        isEditing.value =
-            nameEditor.value?.isEditing ||
-            dynamicEditor.value?.isEditing ||
-            false;
-    },
-);
 </script>
 
 <template>
@@ -40,12 +27,10 @@ watch(
         </span>
         <div>
             <ListCharacteristic
-                ref="nameEditor"
                 :editable="true"
                 :label="$gettext('Name')"
             />
             <ListCharacteristic
-                ref="dynamicEditor"
                 :editable="false"
                 :label="$gettext('Dynamic')"
                 :style="{ width: '4rem' }"

--- a/arches_controlled_lists/src/arches_controlled_lists/components/editor/ValueEditor.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/editor/ValueEditor.vue
@@ -217,11 +217,11 @@ const setRowFocus = (event: DataTableRowEditInitEvent) => {
     rowIndexToFocus.value = event.index;
 };
 
-const makeRowUneditable = (valueId: string) => {
+function makeRowUneditable(valueId: string) {
     editingRows.value = [
         ...editingRows.value.filter((value) => value.id !== valueId),
     ];
-};
+}
 
 const makeValueEditable = (clickedValue: Value, index: number) => {
     if (!editingRows.value.includes(clickedValue)) {

--- a/arches_controlled_lists/src/arches_controlled_lists/components/editor/ValueEditor.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/editor/ValueEditor.vue
@@ -316,6 +316,7 @@ defineExpose({ isEditing });
                                 onUpdated: focusInput,
                             },
                         }"
+                        :style="{ fontSize: 'small' }"
                     />
                     <InputText
                         v-else

--- a/arches_controlled_lists/src/arches_controlled_lists/components/editor/ValueEditor.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/editor/ValueEditor.vue
@@ -20,6 +20,7 @@ import {
     itemKey,
 } from "@/arches_controlled_lists/constants.ts";
 import {
+    commandeerFocusFromDataTable,
     dataIsNew,
     languageNameFromCode,
 } from "@/arches_controlled_lists/utils.ts";
@@ -239,21 +240,15 @@ const inputSelector = computed(() => {
 });
 
 const focusInput = () => {
-    // The editor (pencil) button from the DataTable (elsewhere on page)
-    // immediately hogs focus with a setTimeout of 1,
-    // so we'll get in line behind it to set focus to the input.
-    // This should be reported/clarified with PrimeVue with a MWE.
-    setTimeout(() => {
+    if (rowIndexToFocus.value !== -1) {
         // Note editor uses the second column.
         const indexOfInputCol = valueCategory ? 1 : 0;
-        if (rowIndexToFocus.value !== -1) {
-            const rowEl = editorDiv.value!.querySelector(inputSelector.value);
-            const inputEl = rowEl!.children[indexOfInputCol].children[0];
-            // @ts-expect-error focusVisible not yet in typeshed
-            (inputEl as HTMLInputElement).focus({ focusVisible: true });
-        }
+        const rowEl = editorDiv.value!.querySelector(inputSelector.value);
+        const inputEl = rowEl!.children[indexOfInputCol]
+            .children[0] as HTMLInputElement;
+        commandeerFocusFromDataTable(inputEl);
         rowIndexToFocus.value = -1;
-    }, 25);
+    }
 };
 
 defineExpose({ isEditing });

--- a/arches_controlled_lists/src/arches_controlled_lists/components/editor/ValueEditor.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/editor/ValueEditor.vue
@@ -117,6 +117,10 @@ const headings: Ref<{ heading: string; subheading: string }> = computed(() => {
     }
 });
 
+const isEditing = computed(() => {
+    return editingRows.value.length > 0;
+});
+
 const values = computed(() => {
     if (!item.value) {
         return [];
@@ -167,6 +171,7 @@ const saveValue = async (event: DataTableRowEditInitEvent) => {
 };
 
 const issueDeleteValue = async (value: Value) => {
+    makeRowUneditable(value.id);
     if (dataIsNew(value)) {
         removeItemValue(value);
         return;
@@ -211,6 +216,12 @@ const setRowFocus = (event: DataTableRowEditInitEvent) => {
     rowIndexToFocus.value = event.index;
 };
 
+const makeRowUneditable = (valueId: string) => {
+    editingRows.value = [
+        ...editingRows.value.filter((value) => value.id !== valueId),
+    ];
+};
+
 const makeValueEditable = (clickedValue: Value, index: number) => {
     if (!editingRows.value.includes(clickedValue)) {
         editingRows.value = [...editingRows.value, clickedValue];
@@ -244,6 +255,8 @@ const focusInput = () => {
         rowIndexToFocus.value = -1;
     }, 25);
 };
+
+defineExpose({ isEditing });
 </script>
 
 <template>
@@ -262,6 +275,7 @@ const focusInput = () => {
             striped-rows
             scrollable
             :style="{ fontSize: 'small' }"
+            @row-edit-cancel="(event) => makeRowUneditable(event.data.id)"
             @row-edit-init="setRowFocus"
             @row-edit-save="saveValue"
         >

--- a/arches_controlled_lists/src/arches_controlled_lists/components/tree/AddDeleteControls.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/tree/AddDeleteControls.vue
@@ -140,6 +140,13 @@ const toDelete = computed(() => {
         .map(([k]) => k);
 });
 
+function parseSingleDetail(error: unknown) {
+    if (!(error instanceof Error)) {
+        return undefined;
+    }
+    return error.message.split("\n").slice(0)[0];
+}
+
 const deleteSelected = async () => {
     if (!selectedKeys.value) {
         return;
@@ -161,32 +168,24 @@ const deleteSelected = async () => {
         try {
             anyDeleted = await deleteItems(itemIdsToDelete);
         } catch (error) {
-            if (error instanceof Error) {
-                error.message.split("|").forEach((detail: string) => {
-                    toast.add({
-                        severity: ERROR,
-                        life: DEFAULT_ERROR_TOAST_LIFE,
-                        summary: $gettext("Item deletion failed"),
-                        detail,
-                    });
-                });
-            }
+            toast.add({
+                severity: ERROR,
+                life: DEFAULT_ERROR_TOAST_LIFE,
+                summary: $gettext("Item deletion failed"),
+                detail: parseSingleDetail(error),
+            });
         }
     }
     if (listIdsToDelete.length) {
         try {
             anyDeleted = (await deleteLists(listIdsToDelete)) || anyDeleted;
         } catch (error) {
-            if (error instanceof Error) {
-                error.message.split("|").forEach((detail) => {
-                    toast.add({
-                        severity: ERROR,
-                        life: DEFAULT_ERROR_TOAST_LIFE,
-                        summary: $gettext("List deletion failed"),
-                        detail,
-                    });
-                });
-            }
+            toast.add({
+                severity: ERROR,
+                life: DEFAULT_ERROR_TOAST_LIFE,
+                summary: $gettext("List deletion failed"),
+                detail: parseSingleDetail(error),
+            });
         }
     }
     if (anyDeleted) {

--- a/arches_controlled_lists/src/arches_controlled_lists/components/tree/ListTree.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/tree/ListTree.vue
@@ -5,12 +5,7 @@ import { useGettext } from "vue3-gettext";
 
 import Tree from "primevue/tree";
 
-import { getItemLabel } from "@/arches_vue_utils/utils.ts";
-import {
-    displayedRowKey,
-    selectedLanguageKey,
-    systemLanguageKey,
-} from "@/arches_controlled_lists/constants.ts";
+import { displayedRowKey } from "@/arches_controlled_lists/constants.ts";
 import { routeNames } from "@/arches_controlled_lists/routes.ts";
 import { findNodeInTree, nodeIsList } from "@/arches_controlled_lists/utils.ts";
 import ListTreeControls from "@/arches_controlled_lists/components/tree/ListTreeControls.vue";
@@ -21,11 +16,11 @@ import type { RouteLocationNormalizedLoadedGeneric } from "vue-router";
 import type { TreePassThroughMethodOptions } from "primevue/tree";
 import type { TreeExpandedKeys, TreeSelectionKeys } from "primevue/tree";
 import type { TreeNode } from "primevue/treenode";
-import type { Language } from "@/arches_vue_utils/types";
 import type {
     ControlledList,
     ControlledListItem,
     RowSetter,
+    Value,
 } from "@/arches_controlled_lists/types";
 
 const { $gettext } = useGettext();
@@ -61,8 +56,6 @@ const rerenderTree = ref(0);
 const nextFilterChangeNeedsExpandAll = ref(false);
 const expandedKeysSnapshotBeforeSearch = ref<TreeExpandedKeys>({});
 
-const selectedLanguage = inject(selectedLanguageKey) as Ref<Language>;
-const systemLanguage = inject(systemLanguageKey) as Language;
 const { setDisplayedRow } = inject(displayedRowKey) as unknown as {
     setDisplayedRow: RowSetter;
 };
@@ -224,11 +217,7 @@ function lazyLabelLookup(node: TreeNode) {
     if (nodeIsList(node)) {
         return node.data.name;
     } else {
-        return getItemLabel(
-            node.data,
-            selectedLanguage.value.code,
-            systemLanguage.code,
-        ).value;
+        return node.data.values.map((val: Value) => val.value);
     }
 }
 </script>

--- a/arches_controlled_lists/src/arches_controlled_lists/components/tree/ListTree.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/tree/ListTree.vue
@@ -136,7 +136,6 @@ const updateSelectedAndExpanded = (node: TreeNode) => {
     if (isMultiSelecting.value || movingItem.value?.key) {
         return;
     }
-
     setDisplayedRow(node.data);
     expandedKeys.value = {
         ...expandedKeys.value,

--- a/arches_controlled_lists/src/arches_controlled_lists/components/tree/PresentationControls.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/tree/PresentationControls.vue
@@ -84,6 +84,7 @@ const { $gettext } = useGettext();
 .secondary-button {
     height: 3rem;
     margin: 0.5rem;
+    font-size: smaller;
 }
 
 .language-select {

--- a/arches_controlled_lists/src/arches_controlled_lists/constants.ts
+++ b/arches_controlled_lists/src/arches_controlled_lists/constants.ts
@@ -1,17 +1,17 @@
 import type { InjectionKey, Ref } from "vue";
 import type { Language } from "@/arches_vue_utils/types";
 import type {
-    ControlledList,
     ControlledListItem,
+    DisplayedRowRefAndSetter,
+    IsEditingRefAndSetter,
 } from "@/arches_controlled_lists/types";
 
 // Injection keys
-type DisplayedRowRef = Ref<ControlledList | ControlledListItem | null>;
-export const displayedRowKey = Symbol() as InjectionKey<DisplayedRowRef>;
-type ItemRef = Ref<ControlledListItem>;
-export const itemKey = Symbol() as InjectionKey<ItemRef>;
-type LanguageRef = Ref<Language>;
-export const selectedLanguageKey = Symbol() as InjectionKey<LanguageRef>;
+export const displayedRowKey =
+    Symbol() as InjectionKey<DisplayedRowRefAndSetter>;
+export const isEditingKey = Symbol() as InjectionKey<IsEditingRefAndSetter>;
+export const itemKey = Symbol() as InjectionKey<Ref<ControlledListItem>>;
+export const selectedLanguageKey = Symbol() as InjectionKey<Ref<Language>>;
 export const systemLanguageKey = Symbol() as InjectionKey<Language>;
 
 // Constants

--- a/arches_controlled_lists/src/arches_controlled_lists/types.ts
+++ b/arches_controlled_lists/src/arches_controlled_lists/types.ts
@@ -1,3 +1,5 @@
+import type { Ref } from "vue";
+
 export interface Value {
     id: string;
     valuetype_id: string;
@@ -112,3 +114,24 @@ export interface IconLabels {
     list: string;
     item: string;
 }
+
+// For force-casting injection types (to type-narrow undefined)
+type DisplayedRowRef = Ref<
+    ControlledList | ControlledListItem | NewControlledListItem | null
+>;
+type DisplayedRowSetter = (
+    DisplayedRowRef:
+        | ControlledList
+        | ControlledListItem
+        | NewControlledListItem
+        | null,
+) => void;
+export type DisplayedRowRefAndSetter = {
+    displayedRow: DisplayedRowRef;
+    setDisplayedRow: DisplayedRowSetter;
+};
+
+export type IsEditingRefAndSetter = {
+    isEditing: Ref<boolean>;
+    setIsEditing: (editing: boolean) => void;
+};

--- a/arches_controlled_lists/src/arches_controlled_lists/utils.ts
+++ b/arches_controlled_lists/src/arches_controlled_lists/utils.ts
@@ -233,21 +233,20 @@ export const reorderItems = (
     recalculateSortOrderRecursive(list, list.items);
 };
 
-// Directives
-export const vFocus = {
+export const commandeerFocusFromDataTable = (element: HTMLElement) => {
     /*
     The editor (pencil) button from the DataTable hogs focus with a
     setTimeout of 1, so we'll queue behind it to set focus to the input.
     This should be reported/clarified with PrimeVue with a MWE.
     */
-    mounted: (el: HTMLInputElement) => {
-        // @ts-expect-error focusVisible not yet in typeshed
-        setTimeout(() => el && el.focus({ focusVisible: true }), 5);
-    },
-    updated: (el: HTMLInputElement) => {
-        // @ts-expect-error focusVisible not yet in typeshed
-        setTimeout(() => el && el.focus({ focusVisible: true }), 5);
-    },
+    // @ts-expect-error focusVisible not yet in typeshed
+    setTimeout(() => element && element.focus({ focusVisible: true }), 10);
+};
+
+// Directives
+export const vFocus = {
+    mounted: commandeerFocusFromDataTable,
+    updated: commandeerFocusFromDataTable,
 };
 
 export const shouldUseContrast = () => {

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
     "name": "arches_controlled_lists",
     "license": "AGPL-3.0-only",
     "scripts": {
-        "build_development": "npm run eslint:check && npm run ts:check && cross-env NODE_OPTIONS=--max-old-space-size=2048 webpack --config ./webpack/webpack.config.dev.js",
-        "build_production": "npm run eslint:check && npm run ts:check && cross-env NODE_OPTIONS=--max-old-space-size=2048 NODE_ENV=production webpack --config ./webpack/webpack.config.prod.js",
-        "build_test": "npm run eslint:check && npm run ts:check && cross-env NODE_OPTIONS=--max-old-space-size=2048 webpack --config ./webpack/webpack.config.dev.js --env test=true",
+        "build_development": "npm run eslint:check && npm run ts:check && cross-env webpack --config ./webpack/webpack.config.dev.js",
+        "build_production": "npm run eslint:check && npm run ts:check && cross-env webpack --config ./webpack/webpack.config.prod.js",
+        "build_test": "npm run eslint:check && npm run ts:check && cross-env webpack --config ./webpack/webpack.config.dev.js --env test=true",
         "eslint:check": "eslint **/src",
         "eslint:fix": "eslint **/src --fix",
         "eslint:watch": "nodemon --watch . --ext ts,vue --exec npm run --silent eslint:check",
@@ -14,7 +14,7 @@
         "prettier:fix": "prettier arches_controlled_lists/src --write",
         "ts:check": "vue-tsc --noEmit",
         "ts:watch": "vue-tsc --watch --noEmit",
-        "start": "cross-env NODE_OPTIONS=--max-old-space-size=2048 webpack serve --config ./webpack/webpack.config.dev.js",
+        "start": "cross-env webpack serve --config ./webpack/webpack.config.dev.js",
         "vitest": "vitest --run --coverage"
     },
     "dependencies": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Framework :: Django",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.2",

--- a/tests/reference_datatype_tests.py
+++ b/tests/reference_datatype_tests.py
@@ -189,7 +189,7 @@ class ReferenceDataTypeTests(TestCase):
                 "data": {
                     "72048cb3-adbc-11e6-9ccf-14109fd34195": [
                         {
-                            "uri": "https://rdm.dev.fargeo.com/plugins/controlled-list-manager/item/9baf3cd5-33d4-4fbc-b1d1-a2d218732f1e",
+                            "uri": "https://lingo.dev.fargeo.com/plugins/controlled-list-manager/item/9baf3cd5-33d4-4fbc-b1d1-a2d218732f1e",
                             "labels": [
                                 {
                                     "id": "ea5c8af7-9933-4356-b537-0330c9da4690",


### PR DESCRIPTION
- Improve size of toast details
- Allow searching tree against any language's values
- Show confirm modal when navigating away from unsaved changes
- Restore focus to last editing element when cancelling unsaved changes modal
- Prevent initiating multiple edits

Some cosmetic updates also while I was poking around. Perhaps easier to review commit by commit.