### PR TITLE
fixes reference select widget issues

### DIFF
--- a/arches_controlled_lists/media/js/views/components/widgets/reference-select.js
+++ b/arches_controlled_lists/media/js/views/components/widgets/reference-select.js
@@ -3,11 +3,7 @@ import ReferenceSelectViewModel from 'viewmodels/reference-select';
 import referenceSelectTemplate from 'templates/views/components/widgets/reference-select.htm';
 import 'bindings/select2-query';
 
-const viewModel = function(params) {
-    ReferenceSelectViewModel.apply(this, [params]);
-};
-
 export default ko.components.register('reference-select-widget', {
-    viewModel: viewModel,
+    viewModel: ReferenceSelectViewModel,
     template: referenceSelectTemplate,
 });

--- a/arches_controlled_lists/templates/views/components/widgets/reference-select.htm
+++ b/arches_controlled_lists/templates/views/components/widgets/reference-select.htm
@@ -19,7 +19,7 @@
                         select2Config: select2Config
                     },
                     attr: {'data-label': label, 'aria-label': label}
-                ">
+                "></select>
         </div>
     </div>
 </div>
@@ -51,7 +51,7 @@
                 select2Config: select2Config
             },
             attr: {'data-label': label, 'aria-label': label}
-        ">
+        "></select>
 </div>
 {% endblock config_form %}
 


### PR DESCRIPTION
`<select>` without a closing tag breaks things :( 

I also updated the js file to be more standard.