### PR TITLE
Fix list membership assignment when moving item #117

### DIFF
--- a/arches_controlled_lists/settings.py
+++ b/arches_controlled_lists/settings.py
@@ -100,7 +100,7 @@ TERM_SEARCH_TYPES = [
         "type": "concept",
         "label": _("Concepts"),
         "key": "concepts",
-        "module": "arches.app.search.search_term.ConceptSearch",
+        "module": "arches.app.search.concept_search.ConceptSearch",
     },
     {
         "type": "reference",

--- a/arches_controlled_lists/src/arches_controlled_lists/components/tree/TreeRow.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/components/tree/TreeRow.vue
@@ -145,7 +145,7 @@ const setParent = async (parentNode: TreeNode) => {
         siblings.push(item);
     } else {
         item.parent_id = parentNode.key;
-        list = findNodeInTree(tree.value, item.list_id).found!.data;
+        list = findNodeInTree(tree.value, parentNode.data.list_id).found!.data;
         siblings = parentNode.data.children;
         siblings.push(item);
     }


### PR DESCRIPTION
Closes #117

Before, when moving items to an item target in a new list, the code looked to the wrong data point (origin list, not target item's list) to determine the target list.