### PR TITLE
Fetch list items during resort operation #111

### DIFF
--- a/arches_controlled_lists/models.py
+++ b/arches_controlled_lists/models.py
@@ -125,8 +125,11 @@ class List(models.Model):
 
         reordered_items = []
         exclude_fields = field_names(ListItem()) - {"sortorder", "parent_id"}
+        existing_items = ListItem.objects.filter(pk__in=sortorder_map).in_bulk()
+
         for item_id, sortorder in sortorder_map.items():
-            item = ListItem(pk=uuid.UUID(item_id), sortorder=sortorder)
+            item = existing_items[uuid.UUID(item_id)]
+            item.sortorder = sortorder
             if item_id in parent_map:
                 new_parent = parent_map[item_id]
                 item.parent_id = uuid.UUID(new_parent) if new_parent else None

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -335,7 +335,7 @@ class ListTests(TestCase):
         )
 
     def test_move_list_item(self):
-        """Move the top-level item in list2, which has children, into list1."""
+        """Move the top-level item in list2, which has 4 children, into list1."""
         self.client.force_login(self.admin)
 
         body = {
@@ -359,7 +359,7 @@ class ListTests(TestCase):
             .values_list("sortorder", flat=True),
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
         )
-        self.assertEqual(self.list1.list_items.filter(parent=None).count(), 6)
+        self.assertEqual(self.list1.list_items.exclude(parent=None).count(), 4)
 
     def test_recursive_cycles(self):
         self.client.force_login(self.admin)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -359,6 +359,7 @@ class ListTests(TestCase):
             .values_list("sortorder", flat=True),
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
         )
+        self.assertEqual(self.list1.list_items.filter(parent=None).count(), 6)
 
     def test_recursive_cycles(self):
         self.client.force_login(self.admin)


### PR DESCRIPTION
When moving an item in the controlled list manager, parent information was being nulled out, causing problems calculating depth for the reference select widget, among others.

Closes #111