### PR TITLE
Address tech debt from redefining sortorder to apply across siblings only

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ For developer install instructions, see the [Developer Setup](#developer-setup-f
 
 1. If you don't already have an Arches project, you'll need to create one by following the instructions in the Arches [documentation](http://archesproject.org/documentation/).
 
-2. When your project is ready, add "arches_querysets", "arches_component_lab", "arches_controlled_lists", and "pgtrigger" to INSTALLED_APPS **below** the name of your project:
+2. When your project is ready, add "django.contrib.postgres", "arches_querysets", "arches_component_lab", "arches_controlled_lists", and "pgtrigger" to INSTALLED_APPS **below** the name of your project:
     ```
     INSTALLED_APPS = (
         ...
         "my_project_name",
+        "django.contrib.postgres",
         "arches_querysets",
         "arches_component_lab",
         "arches_controlled_lists",

--- a/arches_controlled_lists/datatypes/datatypes.py
+++ b/arches_controlled_lists/datatypes/datatypes.py
@@ -1,8 +1,8 @@
 import uuid
 from dataclasses import asdict, dataclass
-from itertools import chain
 from typing import Iterable, Mapping
 
+from django.db.models import F
 from django.utils.translation import gettext as _
 
 from arches.app.datatypes.base import BaseDataType
@@ -184,7 +184,7 @@ class ReferenceDataType(BaseDataType):
             return None
         return (
             ListItem.objects.filter(list_id=list_id, list_item_values__value=value)
-            .order_by("sortorder")
+            .order_by(F("parent").asc(nulls_first=True), "sortorder")
             .first()
         )
 

--- a/arches_controlled_lists/settings.py
+++ b/arches_controlled_lists/settings.py
@@ -153,6 +153,7 @@ INSTALLED_APPS = (
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django.contrib.gis",
+    "django.contrib.postgres",
     "django_hosts",
     "arches_controlled_lists",
     "arches_querysets",

--- a/arches_controlled_lists/src/arches_controlled_lists/types.ts
+++ b/arches_controlled_lists/src/arches_controlled_lists/types.ts
@@ -87,7 +87,7 @@ export interface ControlledListItem {
     values: Value[];
     images: ControlledListItemImage[];
     children: ControlledListItem[];
-    parent_id: string;
+    parent_id: string | null;
     depth: number;
 }
 

--- a/arches_controlled_lists/src/arches_controlled_lists/utils.spec.ts
+++ b/arches_controlled_lists/src/arches_controlled_lists/utils.spec.ts
@@ -3,7 +3,12 @@ import {
     HIDDEN_LABEL,
     PREF_LABEL,
 } from "@/arches_controlled_lists/constants.ts";
-import { getItemLabel, rankLabel } from "@/arches_controlled_lists/utils.ts";
+import {
+    getItemLabel,
+    rankLabel,
+    reorderItems,
+} from "@/arches_controlled_lists/utils.ts";
+import { controlled_lists } from "../../../tests/fixtures/data/sample_list_api_response.json";
 
 import type { Label } from "@/arches_controlled_lists/types";
 
@@ -93,5 +98,29 @@ describe("getItemLabel() util", () => {
                 systemLanguageCode,
             ).language_id,
         ).toEqual(systemLanguageCode);
+    });
+});
+
+describe("reorderItems() util", () => {
+    it("reorders a set of siblings from 0", () => {
+        reorderItems(
+            controlled_lists[0],
+            controlled_lists[0].items[0],
+            controlled_lists[0].items,
+            false,
+        );
+        expect(controlled_lists[0].items.map((item) => item.sortorder)).toEqual(
+            [0, 1],
+        );
+        expect(
+            controlled_lists[0].items[0].children.map(
+                (child) => child.sortorder,
+            ),
+        ).toEqual([0]);
+        expect(
+            controlled_lists[0].items[1].children.map(
+                (child) => child.sortorder,
+            ),
+        ).toEqual([0]);
     });
 });

--- a/arches_controlled_lists/src/arches_controlled_lists/utils.ts
+++ b/arches_controlled_lists/src/arches_controlled_lists/utils.ts
@@ -212,32 +212,8 @@ export const reorderItems = (
     siblings: ControlledListItem[],
     up: boolean,
 ) => {
-    /* This isn't child's play because sort order is "flat", whereas
-    reordering involves moving hierarchy subsets.
-
-    With this tree:
-        1
-        |- 2
-        |- 3
-        4
-        5
-
-    Moving the first item "down" one should result in:
-        1
-        2
-        |- 3
-        |- 4
-        5
-
-        (1 -> 4)
-        (2 -> 1)
-        (3 -> 2)
-        (4 -> 3)
-        (5 -> 5)
-
-    We're going to accomplish this by reordering the moved item among
-    its immediate siblings, and then recalculating sort order through the
-    entire list. The python view will just care that the sortorder
+    /* Recalculate sort order through the entire list after a move operation.
+    The python view will just care that the sortorder
     value is correct, not that the items actually present in that order
     in the JSON data, but we're still going to reorder the JSON so we can
     use it to update client state if the server returns an empty success msg.
@@ -273,11 +249,10 @@ export const reorderItems = (
         }
     }
 
-    let acc = 0;
-    const recalculateSortOrderRecursive = (
+    function recalculateSortOrderRecursive(
         parent: Selectable,
         items: ControlledListItem[],
-    ) => {
+    ) {
         // Patch in the reordered siblings.
         if (
             patchSiblings &&
@@ -290,12 +265,12 @@ export const reorderItems = (
             }
             items = reorderedSiblings;
         }
-        for (const thisItem of items) {
-            thisItem.sortorder = acc;
-            acc += 1;
+        // Renumber siblings starting at 0.
+        items.forEach((thisItem, i) => {
+            thisItem.sortorder = i;
             recalculateSortOrderRecursive(thisItem, thisItem.children);
-        }
-    };
+        });
+    }
 
     recalculateSortOrderRecursive(list, list.items);
 };

--- a/arches_controlled_lists/src/arches_controlled_lists/widgets/ReferenceSelectWidget/ReferenceSelectWidget.vue
+++ b/arches_controlled_lists/src/arches_controlled_lists/widgets/ReferenceSelectWidget/ReferenceSelectWidget.vue
@@ -6,10 +6,6 @@ import Skeleton from "primevue/skeleton";
 import ReferenceSelectWidgetEditor from "@/arches_controlled_lists/widgets/ReferenceSelectWidget/components/ReferenceSelectWidgetEditor.vue";
 import ReferenceSelectWidgetViewer from "@/arches_controlled_lists/widgets/ReferenceSelectWidget/components/ReferenceSelectWidgetViewer.vue";
 
-import {
-    fetchWidgetData,
-    fetchNodeData,
-} from "@/arches_component_lab/widgets/api.ts";
 import { EDIT, VIEW } from "@/arches_controlled_lists/widgets/constants.ts";
 
 import type { WidgetMode } from "@/arches_controlled_lists/widgets/types.ts";
@@ -33,8 +29,8 @@ const nodeData = ref();
 const widgetData = ref();
 
 onMounted(async () => {
-    widgetData.value = await fetchWidgetData(props.graphSlug, props.nodeAlias);
-    nodeData.value = await fetchNodeData(props.graphSlug, props.nodeAlias);
+    // widgetData.value = await fetchWidgetData(props.graphSlug, props.nodeAlias);
+    // nodeData.value = await fetchNodeData(props.graphSlug, props.nodeAlias);
 
     isLoading.value = false;
 });

--- a/tests/fixtures/data/sample_list_api_response.json
+++ b/tests/fixtures/data/sample_list_api_response.json
@@ -1,0 +1,124 @@
+{
+    "controlled_lists": [
+        {
+            "dynamic": false,
+            "id": "14bac0aa-9ec6-4a77-b63c-6680b001575d",
+            "items": [
+                {
+                    "children": [
+                        {
+                            "children": [
+                                {
+                                    "children": [],
+                                    "depth": 2,
+                                    "guide": false,
+                                    "id": "ef296efc-95a0-4f9e-b083-9368098ebf09",
+                                    "images": [],
+                                    "list_id": "14bac0aa-9ec6-4a77-b63c-6680b001575d",
+                                    "parent_id": "b3762aac-b1f5-46f1-a50e-fda0501914e0",
+                                    "sortorder": 0,
+                                    "uri": "http://localhost:8000/plugins/controlled-list-manager/item/ef296efc-95a0-4f9e-b083-9368098ebf09",
+                                    "values": [
+                                        {
+                                            "id": "b3a606f6-2b34-4c4f-8deb-c2f8e8584de4",
+                                            "language_id": "en",
+                                            "list_item_id": "ef296efc-95a0-4f9e-b083-9368098ebf09",
+                                            "value": "Grandchild",
+                                            "valuetype_id": "prefLabel"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "depth": 1,
+                            "guide": false,
+                            "id": "b3762aac-b1f5-46f1-a50e-fda0501914e0",
+                            "images": [],
+                            "list_id": "14bac0aa-9ec6-4a77-b63c-6680b001575d",
+                            "parent_id": "97e5c362-4977-4652-b85b-e65643e06594",
+                            "sortorder": 0,
+                            "uri": "http://localhost:8000/plugins/controlled-list-manager/item/b3762aac-b1f5-46f1-a50e-fda0501914e0",
+                            "values": [
+                                {
+                                    "id": "1437e79f-d3eb-407a-bbaa-3f492c885aba",
+                                    "language_id": "en",
+                                    "list_item_id": "b3762aac-b1f5-46f1-a50e-fda0501914e0",
+                                    "value": "Child",
+                                    "valuetype_id": "prefLabel"
+                                }
+                            ]
+                        }
+                    ],
+                    "depth": 0,
+                    "guide": false,
+                    "id": "97e5c362-4977-4652-b85b-e65643e06594",
+                    "images": [],
+                    "list_id": "14bac0aa-9ec6-4a77-b63c-6680b001575d",
+                    "parent_id": null,
+                    "sortorder": 0,
+                    "uri": "http://localhost:8000/plugins/controlled-list-manager/item/97e5c362-4977-4652-b85b-e65643e06594",
+                    "values": [
+                        {
+                            "id": "c3e25a37-691d-4ab2-9f6b-e934e6ccd88c",
+                            "language_id": "en",
+                            "list_item_id": "97e5c362-4977-4652-b85b-e65643e06594",
+                            "value": "Parent",
+                            "valuetype_id": "prefLabel"
+                        }
+                    ]
+                },
+                {
+                    "children": [
+                        {
+                            "children": [],
+                            "depth": 1,
+                            "guide": false,
+                            "id": "685da5a5-1b8f-4908-b250-ed1985bc3670",
+                            "images": [],
+                            "list_id": "14bac0aa-9ec6-4a77-b63c-6680b001575d",
+                            "parent_id": "d37748cc-ab4d-49a1-9047-cf723625ebc1",
+                            "sortorder": 0,
+                            "uri": "http://localhost:8000/plugins/controlled-list-manager/item/685da5a5-1b8f-4908-b250-ed1985bc3670",
+                            "values": [
+                                {
+                                    "id": "3664d51e-92ad-4e13-9dc7-3bd245d45f0f",
+                                    "language_id": "en",
+                                    "list_item_id": "685da5a5-1b8f-4908-b250-ed1985bc3670",
+                                    "value": "Child of Parent 2",
+                                    "valuetype_id": "prefLabel"
+                                }
+                            ]
+                        }
+                    ],
+                    "depth": 0,
+                    "guide": false,
+                    "id": "d37748cc-ab4d-49a1-9047-cf723625ebc1",
+                    "images": [],
+                    "list_id": "14bac0aa-9ec6-4a77-b63c-6680b001575d",
+                    "parent_id": null,
+                    "sortorder": 1,
+                    "uri": "http://localhost:8000/plugins/controlled-list-manager/item/d37748cc-ab4d-49a1-9047-cf723625ebc1",
+                    "values": [
+                        {
+                            "id": "930267e3-6359-452e-9414-40f1c1e74795",
+                            "language_id": "en",
+                            "list_item_id": "d37748cc-ab4d-49a1-9047-cf723625ebc1",
+                            "value": "Parent 2",
+                            "valuetype_id": "prefLabel"
+                        }
+                    ]
+                }
+            ],
+            "name": "Test list",
+            "nodes": [
+                {
+                    "graph_id": "e8736c81-d8d6-478d-945e-e57000bc38a4",
+                    "graph_name": "Test model",
+                    "id": "c76e56e4-79c1-4ac5-94f2-dfff13728dd3",
+                    "name": "Reference node",
+                    "nodegroup_id": "87d0b6f2-1daf-46bc-9538-c6cc5c95b63c"
+                }
+            ],
+            "searchable": false
+        }
+    ]
+}


### PR DESCRIPTION
After #119 changed the meaning of `ListItem.sortorder` to be per sibling rather than per list, there were some follow-ups to handle:

- [Simplify sortorder calculation to renumber among siblings at 0](https://github.com/archesproject/arches-controlled-lists/commit/fc426ae8136c2c9228a23aa1b312659397d667eb)
- [Make flat list items endpoint return logical sort](https://github.com/archesproject/arches-controlled-lists/commit/cfbda4de4b36cabd95021aab6f2947b9ce9d2362)
- [Keep lookup_listitem_from_label() deterministic](https://github.com/archesproject/arches-controlled-lists/commit/67b22aabd2419da363ac786a6196a62e377a1650)
- [Create correct sortorder value on POST](https://github.com/archesproject/arches-controlled-lists/commit/d6b376121088061f45878bcfe1fe428eb01876db)

I happened to have bleeding edge Django checked out and noticed a system check error for omitting `django.contrib.postgres` from INSTALLED_APPS, which we now need given we're using `ExclusionConstraint`, so I updated the readme (and will update my list of cleanups for lingo).