### PR TITLE
Register custom serializer field for reference DT

### DIFF
--- a/arches_controlled_lists/apps.py
+++ b/arches_controlled_lists/apps.py
@@ -1,8 +1,21 @@
-from django.apps import AppConfig
-from django.conf import settings
+from django.apps import AppConfig, apps
 
 
 class ArchesControlledListsConfig(AppConfig):
     name = "arches_controlled_lists"
     verbose_name = "Arches Controlled Lists"
     is_arches_application = True
+
+    def ready(self):
+        if apps.get_app_config("arches_querysets"):
+            from arches_controlled_lists.datatypes.datatypes import (
+                ReferenceField,
+                ReferenceSerializer,
+            )
+            from arches_querysets.rest_framework.serializers import (
+                TileAliasedDataSerializer,
+            )
+
+            TileAliasedDataSerializer.register_custom_datatype_field(
+                ReferenceField, ReferenceSerializer
+            )

--- a/arches_controlled_lists/datatypes/datatypes.py
+++ b/arches_controlled_lists/datatypes/datatypes.py
@@ -2,7 +2,7 @@ import uuid
 from dataclasses import asdict, dataclass
 from typing import Iterable, Mapping
 
-from django.db.models import F
+from django.db.models import F, JSONField
 from django.utils.translation import gettext as _
 
 from arches.app.datatypes.base import BaseDataType
@@ -10,6 +10,19 @@ from arches.app.models.models import Node
 from arches.app.models.graph import GraphValidationError
 
 from arches_controlled_lists.models import ListItem
+
+try:
+    import rest_framework.fields
+except:
+    pass
+else:
+
+    class ReferenceSerializer(rest_framework.fields.JSONField):
+        def to_internal_value(self, data):
+            return ReferenceDataType().to_python(data)
+
+
+class ReferenceField(JSONField): ...
 
 
 @dataclass(kw_only=True)
@@ -29,6 +42,8 @@ class Reference:
 
 
 class ReferenceDataType(BaseDataType):
+    model_field = ReferenceField(null=True)
+
     def to_python(
         self, value: Iterable[Mapping] | None, **kwargs
     ) -> list[Reference] | None:

--- a/arches_controlled_lists/datatypes/datatypes.py
+++ b/arches_controlled_lists/datatypes/datatypes.py
@@ -168,12 +168,10 @@ class ReferenceDataType(BaseDataType):
 
         final_tile_values = []
         for single_value in pre_processed_values:
-            found_item: ListItem | None = None
+            found_item: ListItem | Reference | None = None
             match single_value:
                 case Reference():
-                    found_item = ListItem.objects.filter(
-                        pk=single_value.labels[0].list_item_id
-                    ).first()
+                    found_item = single_value
                 case uuid.UUID():
                     found_item = ListItem.objects.filter(pk=list_item_id).first()
                 case str():
@@ -190,7 +188,10 @@ class ReferenceDataType(BaseDataType):
                     raise TypeError(type(single_value))
 
             if found_item:
-                final_tile_values.append(found_item.build_tile_value())
+                if isinstance(found_item, Reference):
+                    final_tile_values.append(found_item.serialize())
+                else:
+                    final_tile_values.append(found_item.build_tile_value())
 
         return final_tile_values
 

--- a/arches_controlled_lists/datatypes/datatypes.py
+++ b/arches_controlled_lists/datatypes/datatypes.py
@@ -189,7 +189,7 @@ class ReferenceDataType(BaseDataType):
 
             if found_item:
                 if isinstance(found_item, Reference):
-                    final_tile_values.append(found_item.serialize())
+                    final_tile_values.append(asdict(found_item))
                 else:
                     final_tile_values.append(found_item.build_tile_value())
 


### PR DESCRIPTION
Incoming JSON from the DRF API now deserializes to `Reference` objects in python.

This fixes the issue reported in a recent lingo standup about `dict`s not being handled in `transform_value_for_tile()`, since now they're `Reference` objects.

Also provides a model for how to do this for other custom datatypes, e.g in HERs etc.