### PR TITLE
Use same url pattern as modular reports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
     "arches>=8.0.1",
-    "arches_component_lab @ git+https://github.com/archesproject/arches-component-lab.git@main",
+    "arches_component_lab @ git+https://github.com/archesproject/arches-component-lab@main",
 ]
 version = "1.0.0b1"
 


### PR DESCRIPTION
Combining usage of github urls with and without the .git extension to point to dependency branches can cause a conflict even if the branch is the same. This occurred in an application using both controlled lists and modular reports because controlled lists uses the extension and modular reports doesn't. 

```
ERROR: Cannot install casf-database because these package versions have conflicting dependencies.

The conflict is caused by:
    arches-controlled-lists 1.0.0b1 depends on arches-component-lab 0.0.1a2 (from git+https://github.com/archesproject/arches-component-lab.git@main)
    arches-modular-reports 1.0.0b2.dev0 depends on arches-component-lab 0.0.1a2 (from git+https://github.com/archesproject/arches-component-lab@main)

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip to attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```