### PR TITLE
Ensure component lab is migrated #165

### DIFF
--- a/arches_controlled_lists/migrations/0005_add_reference_select_widget_mapping.py
+++ b/arches_controlled_lists/migrations/0005_add_reference_select_widget_mapping.py
@@ -27,6 +27,7 @@ def revert_reference_select_widget_mapping(apps, schema_editor):
 class Migration(migrations.Migration):
     dependencies = [
         ("arches_controlled_lists", "0004_reconfigure_listitem_sortorder_constraints"),
+        ("arches_component_lab", "0002_populate_widget_mappings"),
     ]
 
     operations = [


### PR DESCRIPTION
Ensures component lab is migrated before references WidgetMappings in a controlled list migration.

fixes #165 